### PR TITLE
Fix fancy block comment parsing bug

### DIFF
--- a/jsonjsc/parser.py
+++ b/jsonjsc/parser.py
@@ -35,7 +35,7 @@ def parse(s):
                 line[ci] = ' '
                 line[ci-1] = ' '
                 in_multi_line = True
-            elif in_multi_line and c == '*' and line[ci+1] == '/':
+            elif in_multi_line and c == '*' and ci+1 < len(line) and line[ci+1] == '/':
                 line[ci] = ' '
                 line[ci+1] = ' '
                 in_multi_line = False

--- a/jsonjsc/tests/parser_tests.py
+++ b/jsonjsc/tests/parser_tests.py
@@ -78,6 +78,13 @@ TEST_BLOCK_COMMENT_IN_STRING = r'''{
     "test": "mess/**/age"
 }'''
 
+TEST_FANCY_BLOCK_COMMENT = r'''{
+/************************
+This is a fancy comment!
+************************/
+    "test": "message"
+}'''
+
 TEST_JSON_DECODER = r'''{
     /*
     This is a test of the JSON decoder in full
@@ -122,7 +129,6 @@ class JSONCommentParserTests(unittest.TestCase):
     def test_block_comment_single_line_alone_no_tab(self):
         result = parse(TEST_BLOCK_COMMENT_SINGLE_LINE_ALONE_NO_TAB)
         result = result.split('\n')
-        print(result)
         self.assertEqual(result[1], r'                             ')
 
     def test_block_comment_single_line_before(self):
@@ -180,6 +186,14 @@ class JSONCommentParserTests(unittest.TestCase):
         result = parse(TEST_BLOCK_COMMENT_IN_STRING)
         result = result.split('\n')
         self.assertEqual(result[1], r'    "test": "mess/**/age"')
+
+    def test_fancy_block_comment(self):
+        result = parse(TEST_FANCY_BLOCK_COMMENT)
+        result = result.split('\n')
+        self.assertEqual(result[1], r'                         ')
+        self.assertEqual(result[2], r'')
+        self.assertEqual(result[3], r'                         ')
+        self.assertEqual(result[4], r'    "test": "message"')
 
 """
 Test case for JSONDecoder implementation.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="jsonjsc",
-    version="1.1.1",
+    version="1.1.2",
     author="C. Foster",
     author_email="korewananda@gmail.com",
     description="A package to parse out C/JS style block and single line comments from JSON files",


### PR DESCRIPTION
If a block comment start line ends with a asterisk then it would cause an out of bounds error. This fixes that bug.